### PR TITLE
use "serialize" instead of "content" PPI method

### DIFF
--- a/heredoc_bug/heredoc-bug.t
+++ b/heredoc_bug/heredoc-bug.t
@@ -1,0 +1,35 @@
+use warnings;
+use strict;
+
+use Test::More tests => 5;
+use Test::More;
+use File::Copy qw(copy);
+
+
+BEGIN {
+    use_ok( 'Devel::Examine::Subs' ) || print "Bail out!\n";
+    use_ok( 'File::Edit::Portable' ) || print "Bail out!\n";
+}
+
+my $file = 'heredoc_bug/heredoc.pm';
+my $copy = 'heredoc_bug/heredoc.copy';
+
+my $des = Devel::Examine::Subs->new(
+	file => $file,
+	copy => $copy,
+);
+
+my $rw = File::Edit::Portable->new;
+
+$des->inject(
+	inject_after_sub_def => ['test()'],
+);
+
+
+my @c = $rw->read($copy);
+
+is_deeply([@c[4,5,6,7]], [qw(one two three DOC)], 'heredoc left intact');
+
+is ($c[10], "    test()", 'injects test() properly after sub def');
+
+is ($c[17], "    test()", 'injects test() properly after sub def');

--- a/heredoc_bug/heredoc.pm
+++ b/heredoc_bug/heredoc.pm
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+
+my $content = <<DOC;
+one
+two
+three
+DOC
+
+sub one {
+
+    return 1;
+
+}
+
+sub two {
+
+    return 1;
+
+}
+
+
+1;

--- a/lib/Devel/Examine/Subs.pm
+++ b/lib/Devel/Examine/Subs.pm
@@ -764,7 +764,7 @@ sub _read_file {
         $ppi_doc = PPI::Document->new($file);
     }
 
-    @{ $p->{file_contents} } = split /\n/, $ppi_doc->content;
+    @{ $p->{file_contents} } = split /\n/, $ppi_doc->serialize;
 
 
     if (! $p->{file_contents}->[0]){

--- a/t/48-_file.t
+++ b/t/48-_file.t
@@ -40,7 +40,7 @@ BEGIN {#1
     eval { $des->_read_file({ file => $file }); };
     like (
         $@,
-        qr/Can't call method "content" on an undefined/, # PPI error
+        qr/Can't call method "serialize" on an undefined/, # PPI error
         "_read_file() croaks via PPI if a file is invalid or doesn't exist"
     );
 }


### PR DESCRIPTION
CPAN PRC :-)

PPI "content" method will usually delete content of the heredoc, so I replaced it with "serialize" method which handles heredoc correctly.

I placed tests in heredoc_bug/ dir not to mess with other tests that count files under t/. 

Zoran